### PR TITLE
Add app-id as label as well

### DIFF
--- a/chart/dapr-shared/templates/_daemondeployshared.yaml
+++ b/chart/dapr-shared/templates/_daemondeployshared.yaml
@@ -7,6 +7,7 @@
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
+        dapr.io/app-id: {{ .Values.shared.appId }}
         {{- include "dapr-shared.selectorLabels" . | nindent 8 }}
     spec:
       volumes:


### PR DESCRIPTION
`CiliumNetworkPolicy`s require labels. Having the AppId as label would be highly beneficial. 