### PR TITLE
Fix template chart to work with spiffe and with dapr 1.14.4

### DIFF
--- a/chart/dapr-shared/templates/_daemondeployshared.yaml
+++ b/chart/dapr-shared/templates/_daemondeployshared.yaml
@@ -8,6 +8,7 @@
       {{- end }}
       labels:
         dapr.io/app-id: {{ .Values.shared.appId }}
+        #sidecar.istio.io/inject: "false"
         {{- include "dapr-shared.selectorLabels" . | nindent 8 }}
     spec:
       volumes:
@@ -16,7 +17,7 @@
           defaultMode: 420
           sources:
           - serviceAccountToken:
-              audience: dapr.io/sentry
+              audience: {{ .Values.shared.daprd.serviceAccountIdentityToken.audience }}
               expirationSeconds: 7200
               path: token
       - name: shared-data
@@ -42,7 +43,7 @@
           imagePullPolicy: {{ .Values.shared.daprd.image.pullPolicy }}
           args:
           - /daprd
-          - --mode=kubernetes 
+          - --mode=kubernetes
           - --log-level={{ .Values.shared.log.level }}
           - --log-as-json={{ .Values.shared.log.json }}
           - --dapr-http-port={{ .Values.shared.daprd.httpPort }}
@@ -50,12 +51,13 @@
           - --dapr-internal-grpc-port={{ .Values.shared.daprd.internalGrpcPort }}
           - --dapr-listen-addresses={{ .Values.shared.daprd.listenAddresses }}
           - --dapr-public-port={{ .Values.shared.daprd.publicPort }}
+          - --dapr-graceful-shutdown-seconds={{ .Values.shared.daprd.gracefulShutdownSeconds }}
           - --app-id={{ required ".Values.shared.appId is required" .Values.shared.appId }}
           - --app-port={{ required ".Values.shared.remotePort is required" .Values.shared.remotePort }}
           - --app-protocol={{ required ".Values.shared.daprd.app.protocol is required" .Values.shared.daprd.app.protocol }}
-          - --control-plane-address={{ default "dapr-api.dapr-system.svc.cluster.local:80" .Values.shared.controlPlane.operatorAddress }}
-          - --placement-host-address={{ default "dapr-placement-server.dapr-system.svc.cluster.local:50005"  .Values.shared.controlPlane.placementServerAddress }}
-          - --sentry-address={{ default "dapr-sentry.dapr-system.svc.cluster.local:80" .Values.shared.controlPlane.sentryAddress }}
+          - --control-plane-address={{ .Values.shared.controlPlane.operator.address }}:{{ .Values.shared.controlPlane.operator.port }}
+          - --placement-host-address={{ .Values.shared.controlPlane.placementServer.address }}:{{ .Values.shared.controlPlane.placementServer.port }}
+          - --sentry-address={{ .Values.shared.controlPlane.sentry.address }}:{{ .Values.shared.controlPlane.sentry.port }}
           - --enable-metrics={{ .Values.shared.daprd.metrics.enabled }}
           - --metrics-port={{ .Values.shared.daprd.metrics.port }}
           - --enable-mtls={{ .Values.shared.daprd.mtls.enabled }}
@@ -75,30 +77,15 @@
               configMapKeyRef:
                 name: {{ .Release.Name }}-shared-cm
                 key: dapr-trust-anchors
-          - name: DAPR_CERT_CHAIN
-            valueFrom:
-              configMapKeyRef:
-                name: {{ .Release.Name }}-shared-cm
-                key: dapr-cert-chain
-          - name: DAPR_CERT_KEY
-            valueFrom:
-              configMapKeyRef:
-                name: {{ .Release.Name }}-shared-cm
-                key: dapr-cert-key
-          - name: DAPR_CONTROL_PLANE_NAMESPACE
+          - name: DAPR_CONTROLPLANE_NAMESPACE
             value: {{ default "dapr-system" .Values.shared.controlPlane.namespace }}
+          - name: DAPR_SCHEDULER_HOST_ADDRESS
+            value: {{ default "dapr-system" .Values.shared.scheduler.address }}
           - name: DAPR_API_TOKEN
             valueFrom:
               secretKeyRef:
                 name: {{ include "dapr-shared.fullname" . }}
                 key: dapr-api-token
-          {{- if .Values.shared.daprd.app.token }}
-          - name: APP_API_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "dapr-shared.fullname" . }}
-                key: app-api-token
-          {{- end }}
           - name: DAPR_CONTROLPLANE_TRUST_DOMAIN
             value: {{ .Values.shared.controlPlane.trustDomain }}
           - name: NAMESPACE

--- a/chart/dapr-shared/templates/helmhooks.yaml
+++ b/chart/dapr-shared/templates/helmhooks.yaml
@@ -54,6 +54,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    sidecar.istio.io/inject: "false"
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.

--- a/chart/dapr-shared/values.yaml
+++ b/chart/dapr-shared/values.yaml
@@ -11,11 +11,23 @@ shared:
     level: info
     # -- The daprd log format.
     json: true
+  scheduler:
+    address: dapr-scheduler-server-0.dapr-scheduler-server.dapr-system.svc.cluster.local:50006
   controlPlane:
     # -- Namespace where Dapr Control Plane is.
     namespace: "dapr-system"
     # -- Trust Domain used by the Dapr Control Plane
     trustDomain: "cluster.local"
+
+    operator:
+      address: dapr-api.dapr-system.svc.cluster.local
+      port: 80
+    sentry:
+      address: dapr-sentry.dapr-system.svc.cluster.local
+      port: 80
+    placementServer:
+      address: dapr-placement-server.dapr-system.svc.cluster.local
+      port: 50005
   serviceAccount:
     # -- Allows the option to create or not the service account.
     create: true
@@ -42,6 +54,8 @@ shared:
     # -- node selector for shared Dapr
     nodeSelector: {}
   daprd:
+    serviceAccountIdentityToken:
+      audience: spiffe://cluster.local/ns/dapr-system/dapr-sentry
     app:
       # -- Dapr which protocol your application is using. Valid options are `http`` and `grpc``.
       protocol: "http"
@@ -49,6 +63,9 @@ shared:
     token: ""
     # -- The HTTP port for the Dapr API.
     httpPort: 3500
+
+    gracefulShutdownSeconds: -1
+
     # -- gRPC port for the Dapr Internal API to listen on.
     grpcPort: 50001
     # -- gRPC port for the Dapr Internal API to listen on.
@@ -65,7 +82,7 @@ shared:
       # -- Daprd image.
       name: daprd
       # -- Daprd image version.
-      tag: 1.13.5
+      tag: 1.14.4
       # -- Daprd image pull policy.
       pullPolicy: Always
     metrics:


### PR DESCRIPTION
This PR change the chart template to fix the issue https://github.com/dapr/dapr-shared/issues/56 and to be compatible with dapr 1.14.4. In fact the actual version of the chart when use the image tag to 1.14.4 there is an issue about the certs.