### PR TITLE
Allow use a different NS than dapr-system #58

### DIFF
--- a/chart/dapr-shared/templates/_daemondeployshared.yaml
+++ b/chart/dapr-shared/templates/_daemondeployshared.yaml
@@ -65,6 +65,7 @@
           - --enable-api-logging={{ .Values.shared.daprd.apiLogging.enabled }}
           - --app-channel-address={{ .Values.shared.remoteURL }}
           - --config={{ .Values.shared.daprd.config }}
+          - --disableBuiltinK8sSecretStore={{ default "false" .Values.shared.daprd.disableBuiltinK8sSecretStore }}
          {{- if .Values.shared.daprd.appHealth.enabled }}
           - --enable-app-health-check={{ .Values.shared.daprd.appHealth.enabled }}
           - --app-health-check-path={{ default "/healthz" .Values.shared.daprd.appHealth.checkPath }}

--- a/chart/dapr-shared/templates/_daemondeployshared.yaml
+++ b/chart/dapr-shared/templates/_daemondeployshared.yaml
@@ -34,6 +34,9 @@
           args:
             - init
             - --config-map={{ .Release.Name }}-shared-cm
+          env:
+          - name: DAPR_CONTROL_PLANE_NAMESPACE
+            value: {{ default "dapr-system" .Values.shared.controlPlane.namespace }}
       containers:
         - name: daprd
           securityContext:
@@ -62,7 +65,7 @@
           - --enable-api-logging={{ .Values.shared.daprd.apiLogging.enabled }}
           - --app-channel-address={{ .Values.shared.remoteURL }}
           - --config={{ .Values.shared.daprd.config }}
-          {{- if .Values.shared.daprd.appHealth.enabled }}
+         {{- if .Values.shared.daprd.appHealth.enabled }}
           - --enable-app-health-check={{ .Values.shared.daprd.appHealth.enabled }}
           - --app-health-check-path={{ default "/healthz" .Values.shared.daprd.appHealth.checkPath }}
           - --app-health-probe-interval={{ .Values.shared.daprd.appHealth.probeInterval }}


### PR DESCRIPTION

This PR brings the capability to use a different Dapr namespace, different from "dapr-system". This was already supported but the init container tries to generate the ConfigMap using "dapr-system" without replacement capabilities.

This PR also bring the option to use `disableBuiltinK8sSecretStore`, supported by sidecars but not enabled on this chart.